### PR TITLE
Added missing package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
   },
   "dependencies": {
     "acorn": "^3.0.4",
+    "angular-animate": "^1.5.5",
+    "angular-aria": "^1.5.5",
     "angular-material": "^1.0.6",
+    "angular-messages": "^1.5.5",
     "angular-sanitize": "^1.5.0",
     "angular-translate": "~2.11.0",
     "angular-translate-loader-static-files": "~2.11.0",
@@ -46,6 +49,12 @@
     "ssh2": "git+https://github.com/Wyliodrin/ssh2-chrome-app.git#webshell",
     "sweetalert": "^1.1.3",
     "uuid": "^2.0.1"
+  },
+  "peerDependencies": {
+    "angular": "@>=1.3 <1.6",
+    "angular-animate": "^@>=1.3 <1.6",
+    "angular-aria": "@>=1.3 <1.6",
+    "angular-messages": "@>=1.3 <1.6"
   },
   "scripts": {
     "test": "true"


### PR DESCRIPTION
Following the instructions from readme and the build fails.

```
$ npm install
```

Installation ends with the following warnings:

```
npm WARN angular-material@1.0.7 requires a peer of angular-animate@^1.5.0 but none was installed.
npm WARN angular-material@1.0.7 requires a peer of angular-aria@^1.5.0 but none was installed.
npm WARN angular-material@1.0.7 requires a peer of angular-messages@^1.5.0 but none was installed.
```

Trying to build with Grunt:

```
$ grunt
```

Build ends with the following error:

```
>> Error: Cannot find module 'angular-aria' from '/Users/cdog/Workspace/WyliodrinSTUDIO/node_modules/angular-material'
```
