### PR TITLE
fixed missing ID's form French and Romanian translations

### DIFF
--- a/source/public/controllers/DashboardController.js
+++ b/source/public/controllers/DashboardController.js
@@ -25,7 +25,7 @@ module.exports = function ()
 
 	var app = angular.module ('wyliodrinApp');
 
-	app.controller('DashboardController', function($scope, $element, $wyapp, $wydevice, $timeout, $wysignalproperties, $mdDialog){
+	app.controller('DashboardController', function($scope, $element, $wyapp, $wydevice, $timeout, $wysignalproperties, $mdDialog, $filter){
 		debug ('Registering');
 		$scope.project = 
 		{
@@ -128,8 +128,8 @@ module.exports = function ()
 		          // .textContent('All of the banks have agreed to forgive you your debts.')
 		          // .ariaLabel('Lucky day')
 		          // .targetEvent(ev)
-		          .ok('Yes')
-		          .cancel('No');
+		          .ok(($filter('translate')('YES')))
+		          .cancel(($filter('translate')('NO')));
 		    $mdDialog.show(message).then(function() {
 		    	var pos = _.indexOf($scope.project.dashboard, signal);
 		    	mixpanel.track ('Dashboard Erase',

--- a/source/public/translations/messages-en.json
+++ b/source/public/translations/messages-en.json
@@ -774,14 +774,6 @@
     "message": "Ok",
     "description": ""
   },
-  "Yes": {
-    "message": "Yes",
-    "description": ""
-  },
-  "No": {
-    "message": "No",
-    "description": ""
-  },
   "Cancel": {
     "message": "Cancel",
     "description": ""

--- a/source/public/translations/messages-fr.json
+++ b/source/public/translations/messages-fr.json
@@ -359,6 +359,10 @@
     "message": "Connecter à l'adresse",
     "description": ""
   },
+  "AUTHENTICATE_IP": {
+    "message": "IP",
+    "description": ""
+  },
   "AUTHENTICATE_Login": {
     "message": "Connectez-vous avec un utilisateur du dispositif",
     "description": ""
@@ -413,6 +417,10 @@
   },
   "FLASH_FIRMWARE_RunWithoutFlash": {
     "message": "Courir sans écrire",
+    "description": ""
+  },
+  "FLASH_FIRMWARE": {
+    "message": "Flash firmware",
     "description": ""
   },
   "LIBRARY_Library": {
@@ -535,6 +543,18 @@
     "message": "Gestionnaire des tâches",
     "description": ""
   },
+  "File_explorer": {
+    "message": "Explorateur de fichiers",
+    "description": ""
+  },
+  "Show_file_manager": {
+    "message": "Montrer l'explorateur de fichiers",
+    "description": ""
+  },
+  "Hide_file_manager": {
+    "message": "Cacher l'explorateur de fichiers",
+    "description": ""
+  },
   "WYLIODRIN_USERINTERFACE_Error": {
     "message": "pourrait avoir une erreur",
     "description": ""
@@ -650,6 +670,11 @@
     "message":"Utiliser une connexion sécurisée - ssh (fonctionne plus lent)",
     "description":""
   },
+  "DEVICE_Install":
+  {
+    "message":"Installable",
+    "description":""
+  },
   "INSTALL_SelectBoard": {
     "message": "S'il vous plaît sélectionner la carte que vous souhaitez installer sur",
     "description": ""
@@ -677,6 +702,16 @@
   "PROJECT_library":
   {
     "message":"Bibliothèque projets",
+    "description":""
+  },
+  "PLATFORM_windows":
+  {
+    "message":"Windows 10 IoT Core",
+    "description":""
+  },
+  "PLATFORM_linux":
+  {
+    "message":"Linux",
     "description":""
   },
   "PortSelectSerialChrome":
@@ -714,5 +749,247 @@
   "IR829_setup": {
     "message": "Décompressez, entrez le dossier et exécuter le programme d'installation d'installation avec les commandes suivantes:",
     "description": ""
+  },
+  "Empty_folder": {
+    "message": "Dossier vide",
+    "description": ""
+  },
+  "Loading": {
+    "message": "En proces de chargement. . .",
+    "description": ""
+  },
+  "Show_hidden": {
+    "message": "Montrer les chachés",
+    "description": ""
+  },
+  "want_to_delete": {
+    "message": "Êtes-vous sûr que vous voulez le/les supprimer?",
+    "description": ""
+  },
+  "folder_name": {
+    "message": "Choisissez le nom du dossier",
+    "description": ""
+  },
+  "Ok": {
+    "message": "Ok",
+    "description": ""
+  },
+  "Cancel": {
+    "message": "Renoncer",
+    "description": ""
+  },
+  "choose_name": {
+    "message": "Choisissez le nom pour ",
+    "description": ""
+  },
+  "will_upload": {
+    "message": "Le fichier sera téléchargé vers le serveur immédiatement.",
+    "description": ""
+  },
+  "will_download": {
+    "message": "Le fichier sera téléchargé immédiatement.",
+    "description": ""
+  },
+  "folder": {
+    "message": "dossier",
+    "description": ""
+  },
+  "file": {
+    "message": "fichier",
+    "description": ""
+  },
+  "link": {
+    "message": "liaison",
+    "description": ""
+  },
+  "Refresh": {
+    "message": "Recharger",
+    "description": ""
+  },
+  "New_folder": {
+    "message": "Nouveau dossier",
+    "description": ""
+  },
+  "New_file": {
+    "message": "Nouveau fichier",
+    "description": ""
+  },
+  "New_firmware": {
+    "message": "Nouveau Firmware",
+    "description": ""
+  },
+  "Upload_here": {
+    "message": "Téléchargez vers le serveur ici.",
+    "description": ""
+  },
+  "Rename": {
+    "message": "Renommez",
+    "description": ""
+  },
+  "Download": {
+    "message": "",
+    "description": "Téléchargez"
+  },
+  "Delete": {
+    "message": "Supprimer",
+    "description": ""
+  },
+  "Exit": {
+    "message": "Sortir",
+    "description": ""
+  },
+  "FEinexistent_folder": {
+    "message": "Vous avez accessé un dossier inéxistant."
+  },
+  "FEread_permission": {
+    "message": "Vous n'avez pas de permissions pour lire ici."
+  },
+  "FEread_permission_local": {
+    "message": "Vous n'avez pas de permissions pour lire sur votre disk."
+  },
+  "FEwrite_permission": {
+    "message": "Vous n'avez pas de permissions pour écrire ici."
+  },
+  "FEdelete_permission": {
+    "message": "Vous n'avez pas de permissions pour supprimer ici."
+  },
+  "FErename_permission": {
+    "message": "Vous n'avez pas de permissions pour renommer ici."
+  },
+  "FEfile_write": {
+    "message": "L'écrit du fichier sur disk a échoué."
+  },
+  "FEnew_folder": {
+    "message": "Création du nouveau fichier échouée."
+  },
+  "FEdelete": {
+    "message": "Supprimation échouée."
+  },
+  "FErename": {
+    "message" :"L'action de renommer échouée."
+  },
+  "FEupload": {
+    "message": "Téléchargement vers le serveur échoué."
+  },
+  "FEdownload": {
+    "message": "Téléchargement échoué."
+  },
+  "FEexists": {
+    "message": "Un autre fichier/dossier avec le même nom existe ici."
+  },
+  "FEunknown": {
+    "message": "Erreur inconnue"
+  },
+  "FEnot_exists": {
+    "message": "Le fichier/dossier n'existe plus."
+  },
+  "DASHBOARD_values_export": {
+    "message": "Exporter"
+  },
+  "TREEsame_name": {
+    "message": "Un fichier ou un dossier avec le même nom existe à la destination."
+  },
+  "TREEdelete_special": {
+    "message": "Impossible de supprimer."
+  },
+  "TREEdelete_root": {
+    "message": "Impossible de supprimer le dossier racine."
+  },
+  "TREEdelete_software": {
+    "message": "Impossible de supprimer le dossier software."
+  },
+  "TREEno_root": {
+    "message": "Impossible de créer le dossier racine (utilisez New Firmware)."
+  },
+  "PROJECT_NOTEBOOK": {
+    "message": "Notebook"
+  },
+  "GITHUB_EXAMPLE_Example": {
+    "message": "Chargez un exemple"
+  },
+  "GITHUB_EXAMPLE_Empty":
+  {
+    "message": "S'il vous plaît, écrivez le nom du github repositoire qui contient des exemples."
+  },
+  "DEVICE_CONNECTION_BUSY":
+  {
+    "message": "L'appareil est déjà connecté à un autre utilisateur.",
+    "description":""
+  },
+  "Disconnect": {
+    "message": "Déconnectez",
+    "description": ""
+  },
+  "Reboot_Disconnect": {
+    "message": "Redémarrez et Déconnectez",
+    "description": ""
+  },
+  "Poweroff_Disconnect": {
+    "message": "Arrêtez et Déconnectez",
+    "description": ""
+  },
+  "Error": {
+    "message": "Erreur",
+    "description": ""
+  },
+  "Select_board": {
+    "message": "Séléctez la plaque",
+    "description": ""
+  },
+  "Port": {
+    "message": "Port",
+    "description": ""
+  },
+  "Pick_firmware": {
+    "message": "Prennez le firmware",
+    "description": ""
+  },
+  "No_firmware": {
+    "message": "Le firmware n'existe pas",
+    "description": ""
+  },
+  "Run": {
+    "message": "Exécute",
+    "description": ""
+  },
+  "Github": {
+    "message": "Github",
+    "description": ""
+  },
+  "username": {
+    "message": "nom de l'utilisateur",
+    "description": ""
+  },
+  "repository": {
+    "message": "repositoire",
+    "description": ""
+  },
+  "Author": {
+    "message": "Auteur",
+    "description": ""
+  },
+  "Wyliodrin_app_server_version": {
+    "message": "Version de Wyliodrin-app-server",
+    "description": ""
+  },
+  "Libwyliodrin_version": {
+    "message": "Version de Libwyliodrin",
+    "description": ""
+  },
+  "Operating_system": {
+    "message": "Système Opérateur",
+    "description": ""
+  },
+  "Supported_languages": {
+    "message": "Langage de programmation supportés",
+    "description": ""
+  },
+  "status": {
+    "message": "status",
+    "description": ""
+  },
+  "UPDATE_SD_CARD_IMAGE": {
+    "message":"S'il vous plaît, réactualisez l'image du card SD avant que vous exécutiez le projet",
+    "description":""
   }
 }

--- a/source/public/translations/messages-ro.json
+++ b/source/public/translations/messages-ro.json
@@ -359,6 +359,10 @@
     "message": "Conectează-te la adresa",
     "description": ""
   },
+  "AUTHENTICATE_IP": {
+    "message": "IP",
+    "description": ""
+  },
   "AUTHENTICATE_Login": {
     "message": "Conectează-te folosind orice utilizator al dispozitivului",
     "description": ""
@@ -413,6 +417,10 @@
   },
   "FLASH_FIRMWARE_RunWithoutFlash": {
     "message": "Rulează fără a scrie",
+    "description": ""
+  },
+  "FLASH_FIRMWARE": {
+    "message": "Flash firmware",
     "description": ""
   },
   "LIBRARY_Library": {
@@ -533,6 +541,18 @@
   },
   "TASK_MANAGER_TaskManager": {
     "message": "Administrare procese",
+    "description": ""
+  },
+  "File_explorer": {
+    "message": "Explorare de fișiere",
+    "description": ""
+  },
+  "Show_file_manager": {
+    "message": "Afișare administrare fișiere",
+    "description": ""
+  },
+  "Hide_file_manager": {
+    "message": "Ascunde administrare fișiere",
     "description": ""
   },
   "WYLIODRIN_USERINTERFACE_Error": {
@@ -684,6 +704,16 @@
     "message":"Bibliotecă proiecte",
     "description":""
   },
+  "PLATFORM_windows":
+  {
+    "message":"Windows 10 IoT Core",
+    "description":""
+  },
+  "PLATFORM_linux":
+  {
+    "message":"Linux",
+    "description":""
+  },
   "PortSelectSerialChrome":
   {
     "message":"Select Local Computer as port and connect to it. Connect your Arduino to the USB port of your computer.",
@@ -719,5 +749,247 @@
   "IR829_setup": {
     "message": "Unzipuiți, intrați în folder și executați programul de instalare de configurare cu următoarele comenzi:",
     "description": ""
+  },
+  "Empty_folder": {
+    "message": "Fișier gol",
+    "description": ""
+  },
+  "Loading": {
+    "message": "Se încarcă . . .",
+    "description": ""
+  },
+  "Show_hidden": {
+    "message": "Arată fișiere ascunse",
+    "description": ""
+  },
+  "want_to_delete": {
+    "message": "Sunteți sigur că vreți să ștergeți?",
+    "description": ""
+  },
+  "folder_name": {
+    "message": "Alegeți numele directorului",
+    "description": ""
+  },
+  "Ok": {
+    "message": "Ok",
+    "description": ""
+  },
+  "Cancel": {
+    "message": "Renunță",
+    "description": ""
+  },
+  "choose_name": {
+    "message": "Alegeți numele pentru ",
+    "description": ""
+  },
+  "will_upload": {
+    "message": "Fișierul va fi încărcat imediat.",
+    "description": ""
+  },
+  "will_download": {
+    "message": "Fișierul va fi descărcat imediat.",
+    "description": ""
+  },
+  "folder": {
+    "message": "director",
+    "description": ""
+  },
+  "file": {
+    "message": "fișier",
+    "description": ""
+  },
+  "link": {
+    "message": "legătură",
+    "description": ""
+  },
+  "Refresh": {
+    "message": "Reîncărcați",
+    "description": ""
+  },
+  "New_folder": {
+    "message": "Dosar nou",
+    "description": ""
+  },
+  "New_file": {
+    "message": "Fișier nou",
+    "description": ""
+  },
+  "New_firmware": {
+    "message": "Firmware nou",
+    "description": ""
+  },
+  "Upload_here": {
+    "message": "Încărcați pe server aici",
+    "description": ""
+  },
+  "Rename": {
+    "message": "Redenumiți",
+    "description": ""
+  },
+  "Download": {
+    "message": "Descărcați",
+    "description": ""
+  },
+  "Delete": {
+    "message": "Ștergeți",
+    "description": ""
+  },
+  "Exit": {
+    "message": "Ieșire",
+    "description": ""
+  },
+  "FEinexistent_folder": {
+    "message": "Ați accesat un dosar inexistent."
+  },
+  "FEread_permission": {
+    "message": "Nu aveți permisiuni de citire aici."
+  },
+  "FEread_permission_local": {
+    "message": "Nu aveți permisiuni de citire pentru acest fișier de pe discul dvs."
+  },
+  "FEwrite_permission": {
+    "message": "Nu aveți permisiuni de scriere aici."
+  },
+  "FEdelete_permission": {
+    "message": "Nu aveți permisiuni de ștergre aici."
+  },
+  "FErename_permission": {
+    "message": "Nu aveți permisiuni pentru redenumire aici."
+  },
+  "FEfile_write": {
+    "message": "Scrierea fișierului pe disk a eșuat."
+  },
+  "FEnew_folder": {
+    "message": "Crearea unui nou dosar a eșuat. "
+  },
+  "FEdelete": {
+    "message": "Ștergere eșuată. "
+  },
+  "FErename": {
+    "message" :"Redenumire eșuată. "
+  },
+  "FEupload": {
+    "message": "Încărcare eșuată. "
+  },
+  "FEdownload": {
+    "message": "Descărcare eșuată. "
+  },
+  "FEexists": {
+    "message": "Există un alt fișier/director cu aceeași denumire."
+  },
+  "FEunknown": {
+    "message": "Eroare necunoscută."
+  },
+  "FEnot_exists": {
+    "message": "Fișierul/directorul nu mai există."
+  },
+  "DASHBOARD_values_export": {
+    "message": "Exportare"
+  },
+  "TREEsame_name": {
+    "message": "La destinație există un alt fișier/director cu aceeași denumire."
+  },
+  "TREEdelete_special": {
+    "message": "Nu se poate șterge."
+  },
+  "TREEdelete_root": {
+    "message": "Nu se poate șterge directorul rădăcină."
+  },
+  "TREEdelete_software": {
+    "message": "Nu se poate șterge directorul de software."
+  },
+  "TREEno_root": {
+    "message": "Nu se poate crea în directorul rădăcină (folosiți Firmware)."
+  },
+  "PROJECT_NOTEBOOK": {
+    "message": "Notebook"
+  },
+  "GITHUB_EXAMPLE_Example": {
+    "message": "Încărcați un exemplu"
+  },
+  "GITHUB_EXAMPLE_Empty":
+  {
+    "message": "Vă rugăm să scrieți numele unui repository github care conține exemple"
+  },
+  "DEVICE_CONNECTION_BUSY":
+  {
+    "message": "Aparatul este deja conectat cu un alt utilizator.",
+    "description":""
+  },
+  "Disconnect": {
+    "message": "Deconectați",
+    "description": ""
+  },
+  "Reboot_Disconnect": {
+    "message": "Reporniți și Deconectați",
+    "description": ""
+  },
+  "Poweroff_Disconnect": {
+    "message": "Opriți și Deconectați",
+    "description": ""
+  },
+  "Error": {
+    "message": "Eroare",
+    "description": ""
+  },
+  "Select_board": {
+    "message": "Selectați placa",
+    "description": ""
+  },
+  "Port": {
+    "message": "Port",
+    "description": ""
+  },
+  "Pick_firmware": {
+    "message": "Alegeți firmware",
+    "description": ""
+  },
+  "No_firmware": {
+    "message": "Nu există firmware",
+    "description": ""
+  },
+  "Run": {
+    "message": "Rulați",
+    "description": ""
+  },
+  "Github": {
+    "message": "Github",
+    "description": ""
+  },
+  "username": {
+    "message": "nume de utilizator",
+    "description": ""
+  },
+  "repository": {
+    "message": "repository",
+    "description": ""
+  },
+  "Author": {
+    "message": "Autor",
+    "description": ""
+  },
+  "Wyliodrin_app_server_version": {
+    "message": "Versiunea de Wyliodrin-app-server",
+    "description": ""
+  },
+  "Libwyliodrin_version": {
+    "message": "Versiunea de Libwyliodrin",
+    "description": ""
+  },
+  "Operating_system": {
+    "message": "Sistem de operare",
+    "description": ""
+  },
+  "Supported_languages": {
+    "message": "Limbaje acceptate",
+    "description": ""
+  },
+  "status": {
+    "message": "status",
+    "description": ""
+  },
+  "UPDATE_SD_CARD_IMAGE": {
+    "message":"Vă rugăm să actualizați imaginea cardului SD înainte să rulați proiectul.",
+    "description":""
   }
 }


### PR DESCRIPTION
### Description of the Change
I've added around 70 missing IDs and translated the messages from messages-ro.json and messages-fr.json files.

### Benefits
This will translate all the app messages into the user's language (if French or Romanian).

### Possible Drawbacks
Some imperatives used instead of infinitives or nouns (in English are the same, for example "Power off and Disconnect" or "Delete".

### Applicable Issues

None

### Author
Signed-off-by: Ana Secuiu <anasecuiu@yahoo.com>