### PR TITLE
Fixed 'Would you like to delete' translation

### DIFF
--- a/source/public/controllers/DashboardController.js
+++ b/source/public/controllers/DashboardController.js
@@ -124,7 +124,7 @@ module.exports = function ()
 		this.erase = function (signal)
 		{
 			var message = $mdDialog.confirm()
-		          .title(($filter('translate')('want_to_delete'))+' '++signal.title)
+		          .title(($filter('translate')('deleting_el'))+' '+signal.title+'?')
 		          // .textContent('All of the banks have agreed to forgive you your debts.')
 		          // .ariaLabel('Lucky day')
 		          // .targetEvent(ev)

--- a/source/public/controllers/DashboardController.js
+++ b/source/public/controllers/DashboardController.js
@@ -124,7 +124,7 @@ module.exports = function ()
 		this.erase = function (signal)
 		{
 			var message = $mdDialog.confirm()
-		          .title('Would you like to delete '+signal.title+'?')
+		          .title(($filter('translate')('want_to_delete'))+' '++signal.title)
 		          // .textContent('All of the banks have agreed to forgive you your debts.')
 		          // .ariaLabel('Lucky day')
 		          // .targetEvent(ev)

--- a/source/public/translations/messages-es.json
+++ b/source/public/translations/messages-es.json
@@ -775,7 +775,7 @@
     "description": ""
   },
   "want_to_delete": {
-    "message": "Estás seguro que queres borrar esto?",
+    "message": "Estás seguro que queres borrar esto ",
     "description": ""
   },
   "folder_name": {

--- a/source/public/translations/messages-es.json
+++ b/source/public/translations/messages-es.json
@@ -775,6 +775,10 @@
     "description": ""
   },
   "want_to_delete": {
+    "message": "Estás seguro que queres borrar esto?",
+    "description": ""
+  },
+  "deleting_el": {
     "message": "Estás seguro que queres borrar esto ",
     "description": ""
   },

--- a/source/public/translations/messages-fr.json
+++ b/source/public/translations/messages-fr.json
@@ -763,7 +763,7 @@
     "description": ""
   },
   "want_to_delete": {
-    "message": "Êtes-vous sûr que vous voulez le/les supprimer?",
+    "message": "Êtes-vous sûr que vous voulez le/les supprimer ",
     "description": ""
   },
   "folder_name": {

--- a/source/public/translations/messages-fr.json
+++ b/source/public/translations/messages-fr.json
@@ -763,6 +763,10 @@
     "description": ""
   },
   "want_to_delete": {
+    "message": "Êtes-vous sûr que vous voulez le/les supprimer?",
+    "description": ""
+  },
+  "deleting_el": {
     "message": "Êtes-vous sûr que vous voulez le/les supprimer ",
     "description": ""
   },

--- a/source/public/translations/messages-ro.json
+++ b/source/public/translations/messages-ro.json
@@ -763,7 +763,7 @@
     "description": ""
   },
   "want_to_delete": {
-    "message": "Sunteți sigur că vreți să ștergeți?",
+    "message": "Sunteți sigur că vreți să ștergeți ",
     "description": ""
   },
   "folder_name": {

--- a/source/public/translations/messages-ro.json
+++ b/source/public/translations/messages-ro.json
@@ -763,6 +763,10 @@
     "description": ""
   },
   "want_to_delete": {
+    "message": "Sunteți sigur că vreți să ștergeți?",
+    "description": ""
+  },
+  "deleting_el": {
     "message": "Sunteți sigur că vreți să ștergeți ",
     "description": ""
   },


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

<!--

I changed 'would you like to delete' +signal.title into ($filter('translate')('want_to_delete'))+signal.title and now the dialog box should work fine. 
-->

### Benefits

The issue was fixed

### Possible Drawbacks

Fixing the issue I had to change the translation in every language for "want_to_delete". Now the question mark is not there. I don't think it can affect anything but it's something you should look up to. (For the english version there was not any question mark at the end of the sentance, but for the roumanian, french and spanish language there was a ' ? ' at the end of the line.

### Applicable Issues


### Author
Signed-off-by: Dabuleanu Mihai-Catalin <catalindabuleanu@gmail.com>