### PR TITLE
Fixing Connection status overlaps with OS image 

### DIFF
--- a/source/public/controllers/ProjectController.js
+++ b/source/public/controllers/ProjectController.js
@@ -645,7 +645,6 @@ var app = angular.module ('wyliodrinApp');
 			var obj = {name:arg.text,id:makeID($scope.project.tree[0]),isdir:true,isfirmware:true,ftype:arg.type,fport:"auto",children:[]};
 			this.newSomething(obj,$scope.project.tree[0]);
 			checkEmptyFolders($scope.project.tree[0]);
-			console.log($scope.project.tree[0].children.length);
 			if(arg.type=='openmote')
 				this.newSomething({name:'main.cpp',isdir:false,children:[]},$scope.project.tree[0].children[$scope.project.tree[0].children.length-1]);
 			else if(arg.type=='arduino')

--- a/source/public/controllers/ProjectController.js
+++ b/source/public/controllers/ProjectController.js
@@ -645,6 +645,11 @@ var app = angular.module ('wyliodrinApp');
 			var obj = {name:arg.text,id:makeID($scope.project.tree[0]),isdir:true,isfirmware:true,ftype:arg.type,fport:"auto",children:[]};
 			this.newSomething(obj,$scope.project.tree[0]);
 			checkEmptyFolders($scope.project.tree[0]);
+			console.log($scope.project.tree[0].children.length);
+			if(arg.type=='openmote')
+				this.newSomething({name:'main.cpp',isdir:false,children:[]},$scope.project.tree[0].children[$scope.project.tree[0].children.length-1]);
+			else if(arg.type=='arduino')
+				this.newSomething({name:'arduino.ino',isdir:false,children:[]},$scope.project.tree[0].children[$scope.project.tree[0].children.length-1]);
 		};
 
 		this.newSomething = function(obj,parent){

--- a/source/public/dashboardtags/line.js
+++ b/source/public/dashboardtags/line.js
@@ -5,6 +5,8 @@ var angular = require ('angular');
 
 var _ = require ('lodash');
 
+var $ = require ('jquery');
+
 var settings = require ('settings');
 require ('debug').enable (settings.debug);
 var debug = require ('debug')('wyliodrin:lacy:line');
@@ -19,7 +21,7 @@ debug ('Loading');
 module.exports = function ()
 {
 	var app = angular.module ('wyliodrinApp');
-	app.directive ('line', function ($wydevice, $timeout, $wyapp, $mdDialog){
+	app.directive ('line', function ($wydevice, $timeout, $wyapp, $mdDialog, $filter){
 		debug ('Registering');
 		return {
 			restrict: 'E',
@@ -45,6 +47,13 @@ module.exports = function ()
 					    	type: ($scope.signal.properties.logarithmic)?'logarithmic':undefined,
 					    	title: $scope.signal.properties.axisName
 					    },
+						lang:
+						{
+							printChart: $filter('translate')('PrinttheChart'),
+							downloadPNG: $filter('translate')('downloadasPNG'),
+							downloadJPEG: $filter('translate')('downloadasJPEG'),
+							downloadSVG: $filter('translate')('downloadasSVG'),
+						},
 					    exporting:
 						{
 							buttons:
@@ -52,7 +61,7 @@ module.exports = function ()
 								contextButton: {
 									menuItems: Highcharts.getOptions().exporting.buttons.contextButton.menuItems.concat (
 										{
-											text: 'Export Value',
+											text: $filter('translate')('exportvalue'),
 										    onclick: function () {
 										        downloadValue (this);
 										    }

--- a/source/public/translations/messages-en.json
+++ b/source/public/translations/messages-en.json
@@ -802,6 +802,26 @@
     "message": "The file will be downloaded immediately.",
     "description": ""
   },
+  "downloadasPNG": {
+    "message": "Download PNG image",
+    "description": ""
+  },
+  "exportvalue": {
+    "message": "Export Value",
+    "description": ""
+  },
+  "PrinttheChart": {
+    "message": "Print Chart",
+    "description": ""
+  },
+  "downloadasJPEG": {
+    "message": "Download JPEG image",
+    "description": ""
+  },
+  "downloadasSVG": {
+    "message": "Download SVG vector image",
+    "description": ""
+  },
   "folder": {
     "message": "folder",
     "description": ""

--- a/source/public/translations/messages-es.json
+++ b/source/public/translations/messages-es.json
@@ -806,6 +806,26 @@
     "message": "El archivo estará descargado rápidamente.",
     "description": ""
   },
+  "exportvalue": {
+    "message": "Valor de Exportación",
+    "description": ""
+  },
+  "downloadasPNG": {
+    "message": "Descargar imagen PNG",
+    "description": ""
+  },
+  "PrinttheChart": {
+    "message": "Tabla de impresión",
+    "description": ""
+  },
+  "downloadasJPEG": {
+    "message": "Descargar imagen JPEG",
+    "description": ""
+  },
+  "downloadasSVG": {
+    "message": "Descargar la imagen de vector SVG",
+    "description": ""
+  },
   "folder": {
     "message": "folder",
     "description": ""

--- a/source/public/translations/messages-fr.json
+++ b/source/public/translations/messages-fr.json
@@ -794,6 +794,26 @@
     "message": "Le fichier sera téléchargé rapidement.",
     "description": ""
   },
+  "exportvalue": {
+    "message": "Valeur d'exportation",
+    "description": ""
+  },
+  "downloadasPNG": {
+    "message": "Télécharger l'image PNG",
+    "description": ""
+  },
+  "PrinttheChart": {
+    "message": "Imprimer le graphique",
+    "description": ""
+  },
+  "downloadasJPEG": {
+    "message": "Télécharger l'image JPEG",
+    "description": ""
+  },
+  "downloadasSVG": {
+    "message": "Télécharger l'image vectorielle SVG",
+    "description": ""
+  },
   "folder": {
     "message": "dossier",
     "description": ""

--- a/source/public/translations/messages-ro.json
+++ b/source/public/translations/messages-ro.json
@@ -794,6 +794,26 @@
     "message": "Fișierul va fi descărcat imediat.",
     "description": ""
   },
+  "exportvalue": {
+    "message": "Exporta Valoarea",
+    "description": ""
+  },
+  "downloadasPNG": {
+    "message": "Descarca imaginea in format PNG",
+    "description": ""
+  },
+  "PrinttheChart": {
+    "message": "Printeaza Graficul",
+    "description": ""
+  },
+  "downloadasJPEG": {
+    "message": "Descarca imaginea in format JPEG",
+    "description": ""
+  },
+  "downloadasSVG": {
+    "message": "Descarca imaginea in format vector SVG",
+    "description": ""
+  },
   "folder": {
     "message": "director",
     "description": ""

--- a/source/public/views/wyliodrin-userinterface.html
+++ b/source/public/views/wyliodrin-userinterface.html
@@ -160,7 +160,7 @@
 				<div class="{{a.status()}}" >{{status | translate}}</div>
                 <div class="triangle"></div>
         <div class="os-icon" ng-if="connected">
-            <img ng-src="/public/drawable/{{device.platform}}-icon.png" alt="{{ 'PLATFORM_'+device.platform | translate }}"></img>
+            <img ng-src="/public/drawable/{{device.platform}}-icon.png" alt="{{ 'PLATFORM_'+device.platform | translate }}" hspace="50"></img>
             <md-tooltip md-direction="bottom">
               {{ 'PLATFORM_'+device.platform | translate }}
             </md-tooltip>


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

<!--

-->

### Benefits

Now there should not be the OS image over the text
### Possible Drawbacks

For some people the space between the text and the OS image in English, Roumanian and Spanish languages could be annoying

### Applicable Issues

### Author
Signed-off-by: Your Full Name <youremailaddress@emailprovider.domain>